### PR TITLE
set insecure: true to skip verifying freeipa certs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ spec:
   addPrincipal: true
   ca: ipa
   # Do not check certificate of IPA server connection
-  insecure: true
+  insecure: true # unless you can create your own container and inject IPA server CA as trusted.
   # This fixes a bug when adding a service
   ignoreError: true
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ spec:
   addPrincipal: true
   ca: ipa
   # Do not check certificate of IPA server connection
-  insecure: false
+  insecure: true
   # This fixes a bug when adding a service
   ignoreError: true
 


### PR DESCRIPTION
There is no provision in the issuer as of now to provide CA bundle to verify freeIPA TLS certificate, hence this setting should be set to `true` for the readers and users.