### PR TITLE
ClusterIssuer Fix

### DIFF
--- a/api/v1beta1/clusterissuer_types.go
+++ b/api/v1beta1/clusterissuer_types.go
@@ -16,17 +16,31 @@ limitations under the License.
 
 package v1beta1
 
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster
 
 // ClusterIssuer is the Schema for the clusterissuers API
-type ClusterIssuer Issuer
+type ClusterIssuer struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec   IssuerSpec   `json:"spec,omitempty"`
+	Status IssuerStatus `json:"status,omitempty"`
+}
 
 // +kubebuilder:object:root=true
 
 // ClusterIssuerList contains a list of ClusterIssuer
-type ClusterIssuerList IssuerList
+type ClusterIssuerList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []ClusterIssuer `json:"items"`
+}
 
 func init() {
 	SchemeBuilder.Register(&ClusterIssuer{}, &ClusterIssuerList{})

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -58,7 +58,7 @@ func (in *ClusterIssuerList) DeepCopyInto(out *ClusterIssuerList) {
 	in.ListMeta.DeepCopyInto(&out.ListMeta)
 	if in.Items != nil {
 		in, out := &in.Items, &out.Items
-		*out = make([]Issuer, len(*in))
+		*out = make([]ClusterIssuer, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}

--- a/controllers/certificaterequest.go
+++ b/controllers/certificaterequest.go
@@ -89,7 +89,7 @@ func (r *CertificateRequestReconciler) Reconcile(ctx context.Context, req reconc
 
 			return reconcile.Result{}, err
 		}
-	} else if cr.Spec.IssuerRef.Group == "ClusterIssuer" {
+	} else if cr.Spec.IssuerRef.Kind == "ClusterIssuer" {
 		issNamespaceName = types.NamespacedName{
 			Namespace: "",
 			Name:      cr.Spec.IssuerRef.Name,


### PR DESCRIPTION
Hi @guilhem ,

this PR is fixing most of the clusterissuer bugs. 
There is still a problem with deserializing the results from the service_find method. The library seems to think that a bunch of fields are required, when they aren't. The problem seems to be in the go-freeipa library (https://github.com/tehwalris/go-freeipa/blob/master/freeipa/generated.go)

Yusuf

