### PR TITLE
add ignoreError setting into ClusterIsseuer CRD

### DIFF
--- a/config/crd/bases/certmanager.freeipa.org_clusterissuers.yaml
+++ b/config/crd/bases/certmanager.freeipa.org_clusterissuers.yaml
@@ -52,6 +52,9 @@ spec:
                 description: Host remote FreeIPA server
                 minLength: 1
                 type: string
+              ignoreError:
+                default: false
+                type: boolean
               insecure:
                 default: false
                 type: boolean
@@ -100,6 +103,7 @@ spec:
             - addService
             - ca
             - host
+            - ignoreError
             - insecure
             - password
             - serviceName


### PR DESCRIPTION
Hello, firstly thank you for this issuer. While trying it out, I found out that `ignoreError` setting is only possible in Issuer object, not in ClusterIssuer. This is also mentioned in https://github.com/guilhem/freeipa-issuer/issues/15. So this PR adds `ignoreError` setting into ClusterIssuer.